### PR TITLE
Catch bad json parsing of response.

### DIFF
--- a/src/API.js
+++ b/src/API.js
@@ -465,7 +465,7 @@ class Api {
           return this.fetch(path, params, options);
         }
         if (options.method === 'DELETE') return Promise.resolve();
-        return response.json().then(body => {
+        return response.json().catch(() => null).then(body => {
           if (!response.ok) {
             if (body) {
               throw new ApiError(body.message, body.code, response.status);

--- a/test/exp3247.spec.js
+++ b/test/exp3247.spec.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = suite => {
+  describe('EXP-3279', () => {
+    it('API calls to logs endpoint with empty JSON response should resolve to null.', () => {
+      return suite.startAsDevice().post('/api/logs', []).then(response => {
+        if (response !== null) throw new Error();
+      });
+    });
+  });
+};

--- a/test/index.js
+++ b/test/index.js
@@ -51,6 +51,8 @@ require('./getChannel.spec')(suite);
 require('./isConnected.spec')(suite);
 
 require('./exp1511.spec')(suite);
+require('./exp3247.spec')(suite);
+
 require('./get.spec')(suite);
 require('./post.spec')(suite);
 require('./patch.spec')(suite);


### PR DESCRIPTION
There is a test that checks this but with old sdk post of [] to /api/logs gave a json parsing error.